### PR TITLE
More info about various object types

### DIFF
--- a/levelObjects/07_BigStuff/levelBigStuffEntry.md
+++ b/levelObjects/07_BigStuff/levelBigStuffEntry.md
@@ -61,7 +61,7 @@ For surveillance screens, the sources of screens 0-7 are specified in the [Surve
 The following big items support displays:
 7/0/6 (TV), 7/0/7 (COMPUTER MONITOR),
 7/2/6 (SCREEN, small), 7/2/8 (SCREEN, large), 7/2/9 (SCREEN, medium),
-with variation: 7/5/6 (CONTROL PEDESTAL)  (see below)
+with variation: 7/5/5 (CONTROL PANEL), 7/5/6 (CONTROL PEDESTAL)  (see below)
 
 ### Electronics 7/0/x
 
@@ -162,7 +162,7 @@ These have the same layout as the general textureable furniture (see above).
     0003  [7]byte   Unused
 
 
-#### Control Pedestals (with display) 7/5/6
+#### Control Pedestals (with display) 7/5/5, 7/5/6
 
 Control pedestals are similar to displays regarding the source of the display.
 Instead of having different loop options, they trigger an object if used.

--- a/levelObjects/08_SmallStuff/levelSmallStuffEntry.md
+++ b/levelObjects/08_SmallStuff/levelSmallStuffEntry.md
@@ -40,10 +40,33 @@ Nothing special.
 
 **Corpse** (10 bytes)
 
-    0000  [2]byte   Unknown
+    0000  byte      Treasure type
+    0001  byte      Unused
     0002  [4]int16  Object index
 
-> A few corpses have the first byte set to 0x01. Only found with empty corpses, and effect unknown.
+The four ```Object index``` values determine the corpse's loot. More random loot can be added to empty slots based on the ```Treasure type```.
+
+
+**Treasure Type Enumeration** (1 byte)
+
+    0xF5            No treasure
+    0xF6            Humanoid
+    0xF7            Drone
+    0xF8            Assassin
+    0xF9            Warrior cyborg
+    0xFA            Flier bot
+    0xFB            Security 1 bot
+    0xFC            Exec bot
+    0xFD            Cyborg enforcer
+    0xFE            Security 2 bot
+    0xFF            Elite cyborg
+    0x00            Standard corpse
+    0x01            Loot-oriented corpse
+    0x02            Repairbot
+    0x03            Serv-bot
+
+
+> The treasure type values for corpses are the same as for [critter properties](../14_Critter/critterProperties.md), except offset by 11.
 
 #### Severed Heads 8/2/13, 8/2/14
 

--- a/levelObjects/08_SmallStuff/levelSmallStuffEntry.md
+++ b/levelObjects/08_SmallStuff/levelSmallStuffEntry.md
@@ -165,6 +165,17 @@ For 8/5/8 (data fragments), the text index is for text resource ```0x087A```.
 Layout and properties are the same as for force bridges (7/7/7).
 
 
+#### Cyberspace Decoys 8/5/10
+
+**Cyberspace Decoy** (10 bytes)
+
+    0000  [2]byte   Unused
+    0002  int16     Destroy object index
+    0004  [6]byte   Unused
+
+Normally, these cannot be destroyed in cyberspace. However, if placed in a map and made vulnerable to damage, decoys can be made to destroy another object when destroyed.
+
+
 ### Wear and Tear Stuff 8/6/x
 
 Nothing special.

--- a/levelObjects/09_Fixture/levelFixtureEntry.md
+++ b/levelObjects/09_Fixture/levelFixtureEntry.md
@@ -57,10 +57,7 @@ The two ```trigger object index``` values work only with trigger objects, they c
 
 #### Retinal ID Scanner 9/1/6
 
-If the condition field is all zero, the scanner triggers its action when activated with any head item (hacker's eyes are never accepted).
-
-> Although the game uses a condition of ```06 00 00 00```, it does not work as a game variable check nor does it match up with the requested head. So far it is unknown how the scanner is bound to the right head.
-
+When using a head item on the retinal scanner, the condition field is compared against the head's ```Current Frame``` value (for object 8/12/13), or ```Current Frame + 11``` (for object 8/12/14). Note that this is different from the ```Image index``` value which determines how the head appears in the MFD.
 
 ### Stations 9/2/x
 

--- a/levelObjects/09_Fixture/levelFixtureEntry.md
+++ b/levelObjects/09_Fixture/levelFixtureEntry.md
@@ -23,15 +23,22 @@ The conditions for buttons are based on [game variables](../Conditions.md#game-v
 ```Access mask``` is an additional condition for the button. If not zero, the lower five bits can specify one required access level the hacker must have. The remaining 7 bits don't work properly or resolve to the "None" level.
 
 
-### Recepticles 9/1/x
+### Receptacles 9/1/x, 9/4/x
 
-Most recepticles work in conjunction with the quest items (8/7/x). With the exception of antenna relay panels, they contain regular actions as data.
-Unless noted otherwise below, the conditions for recepticles are based on object types.
+Most receptacles work in conjunction with the quest items (8/7/x). With the exception of antenna relay panels, they contain regular actions as data.
+Unless noted otherwise below, the conditions for receptacles are based on object types, with an optional trap message if the wrong item is used.
 
-**Recepticle Fixture Specific Info** (24 bytes)
+**Receptacle Fixture Specific Info** (24 bytes)
 
     0000  [22]byte  Action data
     0016  [2]byte   Unused
+
+**Receptacle Fixture Condition** (4 bytes)
+
+    0000  byte      Object type
+    0001  byte      Object subclass
+    0002  byte      Object class
+    0003  byte      Trap message (optional)
 
 
 #### Antenna Relay Panel 9/1/3
@@ -250,11 +257,6 @@ Combinations must not be entered in sequence, any of the three combinations is v
 If the ```Fail object index``` refers to a valid object, this one is triggered when a wrong combination was entered.
 
 > One number pad on level 0 has the first byte of the input panel structure set to ```0x06```. Purpose and effect unknown.
-
-
-### Vending Machines 9/4/x
-
-These are not available.
 
 
 ### Cyberspace Switches 9/5/x

--- a/levelObjects/12_Trap/levelTrapEntry.md
+++ b/levelObjects/12_Trap/levelTrapEntry.md
@@ -49,9 +49,9 @@ Trigger Types:
     1: Null;            Must be set off externally. Also used as data storage.
     2: Floor;           Hacker touches floor of this tile (per foot exclusively)
     3: Player Death;    Used to resurrect Hacker
-    4: Deatch Watch;    When certain objects (or types of objects) are destroyed. Common for CPU nodes.
-    5: Area Enter;      Unused
-    6: Area Continuous; Unused
+    4: Death Watch;     When certain objects (or types of objects) are destroyed. Common for CPU nodes.
+    5: Area Enter;      Hacker enters (or leaves) a given radius
+    6: Area Continuous; Hacker enters any tile inside (or outside) a given radius
     7: This is not a trigger! See AI hints above.
     8: Level Entry;     Used for instance to initialize starting health
     9: Continuous;      Unused
@@ -65,11 +65,23 @@ Nearly all triggers have conditions based on [game variables](../Conditions.md#g
 
 The following exceptions exist:
 * 4 (Death Watch Trigger): A union of [object type][obj-type-cond] and [object index conditions][obj-index-cond]
+* 5, 6 (Area Trigger): A radius around the trigger. See below.
 * 11 (Ecology Trigger): A combination of [object type][obj-type-cond] and a limit value. See below.
 
 [obj-type-cond]: ./Conditions.md#object-type-conditions
 [obj-index-cond]: ./Conditions.md#object-index-conditions
 
+##### Area Triggers
+
+These triggers activate when the hacker enters or leaves a circular area around the trigger. The radius of this area is determined by the condition.
+
+**Area Trigger Condition** (4 bytes)
+
+    0000  sint32    Radius (in tiles)
+
+If the ```radius``` is between 1 and 4095, the trigger activates when the hacker is within a circular area of that size around the trigger's tile. A negative radius will activate the trigger when the hacker is outside of the circle instead (e.g. if the radius is -5, the trigger activates when the hacker is at least 5 tiles away from the trigger).
+
+Trigger type 5 ("Area Enter") activates once the hacker either enters (positive radius) or leaves (negative radius) the area. Type 6 ("Area Continuous") activates when the hacker enters any tile that is either inside (positive radius) or outside (negative radius) of the area.
 
 ##### Ecology Triggers
 

--- a/levelObjects/14_Critter/critterProperties.md
+++ b/levelObjects/14_Critter/critterProperties.md
@@ -3,6 +3,7 @@
 #### Generic Critter Properties
 
 **Generic Critter Propertes** (`CritterProp` struct) (75 bytes)
+
     0000  byte      Intelligence; unused
     0001  [21]byte  Primary attack info
     0016  [21]byte  Secondary attack info
@@ -42,12 +43,13 @@ The `secondary attack probability` determines how likely the critter will use it
 
 The `disrupt probability` determines how likely the critter will be interrupted when being hit. `0xFF` means always, `0x00` will have the critter execute its attacks and movement without interruptions.
 
-`Treasure type` is an enumeration value (ranging from `0x00` to `0x0E`), pointing into a hardcoded pool of possible loot. See below for the possible constants. The concrete loot is randmoized accordingly.
+`Treasure type` is an enumeration value (ranging from `0x00` to `0x0E`), pointing into a hardcoded pool of possible loot. See below for the possible constants. The concrete loot is randomized accordingly.
 
 The `attack key frame` value is an index into the attack animation, when the corresponding attack should take effect.
 
 
 **Critter Attack Info** (`CritterAttack` struct) (21 bytes)
+
     0000  uint8     Damage type
     0001  uint8     Special damage type
     0002  [2]byte   Unused
@@ -94,7 +96,7 @@ The critter will want to get within the `attack range` to perform its attack.
     0x0A            Elite cyborg
     0x0B            Standard corpse
     0x0C            Loot-oriented corpse
-    0x0D            Electro-stuff treasure
+    0x0D            Repairbot
     0x0E            Serv-bot
 
 


### PR DESCRIPTION
I've recently been digging around in the SS1 source release, partly in order to update/correct some info about unused object types in [this tcrf.net article](https://tcrf.net/System_Shock) that I was working on a while back, and I've found some additional info about various stuff. (Relevant issues: #39, #40, #41, #43)

* The "area" triggers (12/0/5 and 12/0/6) are implemented and use a radius-based condition ([TRIGGER.C:2293-2312](https://github.com/nothings/shockmac/blob/master/ShockMac/game/TRIGGER.C#L2293-L2312))
* The unused vending machine objects (9/4/x) work the same as normal receptacles (9/1/x) ([OBJUSE.C:955](https://github.com/nothings/shockmac/blob/master/ShockMac/game/OBJUSE.C#L955))
* The condition field for normal receptacles (9/1/x) includes an optional trap message if the player tries to use the wrong item ([OBJUSE.C:987-993](https://github.com/nothings/shockmac/blob/master/ShockMac/game/OBJUSE.C#L987-L993))
* The condition field for the retinal scanner is based on the "current frame" value of severed head items, not the MFD image index ([OBJUSE.C:961-964](https://github.com/nothings/shockmac/blob/master/ShockMac/game/OBJUSE.C#L961-L964))
* The unused "control panel" object (7/5/5) works the same as the control pedestal (7/5/6) ([OBJUSE.C:1164](https://github.com/nothings/shockmac/blob/master/ShockMac/game/OBJUSE.C#L1164))
* The first byte of human corpses' SmallStuff struct is the treasure type index for random loot ([AI.C:590-591](https://github.com/nothings/shockmac/blob/master/ShockMac/game/AI.C#L590-L591))

I may be adding some other small things after more investigation/experimenting.